### PR TITLE
Datasource priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--
+- Prefere RADIO data over ADSB data when aircraft came in over multiple datasources. Unless older than 40000000us old, then we insert teh ADSB position. THis is to prevent weird position jumps because ADSB data is usually delayed
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Prefere RADIO data over ADSB data when aircraft came in over multiple datasources. Unless older than 40000000us old, then we insert teh ADSB position. This is to prevent weird position jumps because ADSB data is usually delayed
+- 
+
+### Changed
+
+-
+
+### Deprecated
+
+-
+
+### Removed
+
+-
+
+### Fixed
+
+-
+
+### Security
+
+-
+
+## 2.0.1 - 2026-04-32
+
+### Added
+
+- Prefer radio-derived positions over ADS-B when an aircraft is received from multiple data sources. Only switch to ADS-B if the radio position is older than 4,000,000 µs (4 seconds). This avoids sudden position jumps, as ADS-B data is typically delayed. And we trust radio positions more.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Prefere RADIO data over ADSB data when aircraft came in over multiple datasources. Unless older than 40000000us old, then we insert teh ADSB position. THis is to prevent weird position jumps because ADSB data is usually delayed
+- Prefere RADIO data over ADSB data when aircraft came in over multiple datasources. Unless older than 40000000us old, then we insert teh ADSB position. This is to prevent weird position jumps because ADSB data is usually delayed
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--
+- Prefere RADIO data over ADSB data when aircraft came in over multile datasources. Unless older than 40000000us old, then we insert teh ADSB position. THis is to prevent weird position jumps because ADSB data is usually delayed
 
 ### Changed
 

--- a/src/lib/aircrafttracker/ace/trackerdata.hpp
+++ b/src/lib/aircrafttracker/ace/trackerdata.hpp
@@ -32,6 +32,8 @@ private:
     static constexpr int32_t SLICE_SIZE_MS = 1'000 / TIMESLICES;
     static constexpr int32_t MAX_POSITION_INTERPOLATIONS_USEC = 10'000'000;
     static constexpr int32_t TIME_SEND_HYSTERESIS = 100'000;
+    // Prefer RADIO positions over others for this number of us
+    static constexpr int32_t RADIO_PRIORITY_TIMEOUT_US = 4000000;
 
     struct TrackerEntry
     {
@@ -219,6 +221,18 @@ public:
         if (it != trackedAircraft.end())
         {
             it->second.sendTime = time;
+
+            // Prefer MLAT over ADSB for RADIO_PRIORITY_TIMEOUT_US to avoid jumps.
+            // We assume ADSB/MLAT data is less acurate due to delays in the chain
+            // TODO: We should revise this once all timings are validated (they are within a second, bit in finer detail)
+            const bool trackedIsRadio = it->second.position.dataSource != GATAS::DataSource::ADSB;
+            const bool incomingIsMlat = position.dataSource == GATAS::DataSource::ADSB;
+            const bool radioStillFresh = !CoreUtils::isUsReachedRaw(it->second.position.timestamp + RADIO_PRIORITY_TIMEOUT_US, time);
+            if (trackedIsRadio && incomingIsMlat && radioStillFresh)
+            {
+                return false;
+            }
+
             it->second.position = position;
         }
         else

--- a/src/lib/aircrafttracker/aircrafttracker_tests/trackerdata_test.cpp
+++ b/src/lib/aircrafttracker/aircrafttracker_tests/trackerdata_test.cpp
@@ -255,3 +255,81 @@ TEST_CASE("Should update data", "[single-file]")
 
     REQUIRE(testHandler.callBacks == 1);
 }
+
+TEST_CASE("Radio priority: RADIO 4000000us old, ADSB incoming - should NOT update", "[single-file]")
+{
+    TrackerData<100, 4> trackedAircraft;
+    time_us_Value = 0;
+
+    // Insert radio data at t=0
+    GATAS::AircraftPositionInfo radioPosition;
+    radioPosition.address = 42;
+    radioPosition.timestamp = 0;
+    radioPosition.distanceFromOwn = 5000;
+    radioPosition.dataSource = GATAS::DataSource::OGN1;
+    REQUIRE(trackedAircraft.insert(radioPosition) == true);
+
+    // At t=2000000us, incoming ADSB data arrives
+    // Radio is 2000000us old, well within priority timeout (4000000us)
+    time_us_Value = 2000000;
+    GATAS::AircraftPositionInfo adsbPosition;
+    adsbPosition.address = 42;
+    adsbPosition.timestamp = 2000000;
+    adsbPosition.distanceFromOwn = 5100;
+    adsbPosition.dataSource = GATAS::DataSource::ADSB;
+
+    REQUIRE(trackedAircraft.insert(adsbPosition) == false);
+    REQUIRE(trackedAircraft.size() == 1);
+
+    // Verify radio data was NOT replaced
+    class VerifyNotUpdatedHandler
+    {
+    public:
+        void onNext(const GATAS::AircraftPositionInfo &position)
+        {
+            REQUIRE(position.distanceFromOwn == 5000);  // Should be original radio data
+            REQUIRE(position.dataSource == GATAS::DataSource::OGN1);
+        }
+    } handler;
+    time_us_Value = 2000100;
+    trackedAircraft.sendScheduled(etl::delegate<void(const GATAS::AircraftPositionInfo &)>::create<VerifyNotUpdatedHandler, &VerifyNotUpdatedHandler::onNext>(handler));
+}
+
+TEST_CASE("Radio priority: RADIO 5000000us old, ADSB incoming - should UPDATE", "[single-file]")
+{
+    TrackerData<100, 4> trackedAircraft;
+    time_us_Value = 0;
+
+    // Insert radio data at t=0
+    GATAS::AircraftPositionInfo radioPosition;
+    radioPosition.address = 42;
+    radioPosition.timestamp = 0;
+    radioPosition.distanceFromOwn = 5000;
+    radioPosition.dataSource = GATAS::DataSource::OGN1;
+    REQUIRE(trackedAircraft.insert(radioPosition) == true);
+
+    // At t=5000000us, incoming ADSB data arrives
+    // Radio is 5000000us old, should exceed priority timeout
+    time_us_Value = 5000000;
+    GATAS::AircraftPositionInfo adsbPosition;
+    adsbPosition.address = 42;
+    adsbPosition.timestamp = 5000000;
+    adsbPosition.distanceFromOwn = 5100;
+    adsbPosition.dataSource = GATAS::DataSource::ADSB;
+
+    REQUIRE(trackedAircraft.insert(adsbPosition) == true);
+    REQUIRE(trackedAircraft.size() == 1);
+
+    // Verify ADSB data WAS inserted
+    class VerifyUpdatedHandler
+    {
+    public:
+        void onNext(const GATAS::AircraftPositionInfo &position)
+        {
+            REQUIRE(position.distanceFromOwn == 5100);  // Should be updated ADSB data
+            REQUIRE(position.dataSource == GATAS::DataSource::ADSB);
+        }
+    } handler;
+    time_us_Value = 5000100;
+    trackedAircraft.sendScheduled(etl::delegate<void(const GATAS::AircraftPositionInfo &)>::create<VerifyUpdatedHandler, &VerifyUpdatedHandler::onNext>(handler));
+}


### PR DESCRIPTION
Prefer radio-derived positions over ADS-B when an aircraft is received from multiple data sources. Only switch to ADS-B if the radio position is older than 4,000,000 µs (4 seconds). This avoids sudden position jumps, as ADS-B data is typically delayed. And we trust radio positions more.
